### PR TITLE
change endpoint history before param

### DIFF
--- a/lib/src/api/webim_repository.dart
+++ b/lib/src/api/webim_repository.dart
@@ -61,7 +61,7 @@ abstract class WebimRepository {
       PARAMETER_SURVEY_QUESTION_ID = "question-id",
       PARAMETER_SURVEY_ID = "survey-id",
       PARAMETER_TIMESTAMP = "ts",
-      PARAMETER_TIMESTAMP_BEFORE = "before-ts",
+      PARAMETER_TIMESTAMP_BEFORE = "before",
       PARAMETER_TITLE = "title",
       PARAMETER_VISIT_SESSION_ID = "visit-session-id",
       PARAMETER_VISITOR_EXT = "visitor-ext",

--- a/lib/src/api/webim_repository.g.dart
+++ b/lib/src/api/webim_repository.g.dart
@@ -160,7 +160,7 @@ class _WebimRepository implements WebimRepository {
     final queryParameters = <String, dynamic>{
       'page-id': pageId,
       'auth-token': authorizationToken,
-      'before-ts': timestampBefore
+      'before': timestampBefore
     };
     final _data = <String, dynamic>{};
     final Response<Map<String, dynamic>> _result = await _dio.request(

--- a/lib/src/domain/message.dart
+++ b/lib/src/domain/message.dart
@@ -1,4 +1,5 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:webim_sdk/src/util/num_extension.dart';
 import 'package:webim_sdk/src/exception.dart';
 
 part 'message.g.dart';
@@ -42,11 +43,11 @@ class Message implements Comparable {
   @JsonKey(name: "text")
   final String textValue;
   @JsonKey(name: "ts")
-  final double tsSeconds;
+  final int tsSeconds;
   @JsonKey(name: "modifiedTs")
   final double modified;
   @JsonKey(name: "ts_m")
-  final int tsMicros = -1;
+  final int tsMicros;
   @JsonKey(name: "quote")
   final Quote quote;
 
@@ -66,10 +67,12 @@ class Message implements Comparable {
     this.read,
     this.sessionId,
     this.textValue,
-    this.tsSeconds,
+    int tsSeconds,
+    int tsMicros,
     this.quote,
     this.modified,
-  });
+  })  : tsMicros = tsMicros ?? tsSeconds?.round()?.fromSecToMicro() ?? -1,
+        tsSeconds = tsSeconds?.round() ?? tsMicros?.fromMicroToSec() ?? -1;
 
   factory Message.fromJson(Map<String, dynamic> json) => _$MessageFromJson(json);
 

--- a/lib/src/domain/message.g.dart
+++ b/lib/src/domain/message.g.dart
@@ -25,7 +25,8 @@ Message _$MessageFromJson(Map<String, dynamic> json) {
     read: json['read'] as bool,
     sessionId: json['sessionId'] as String,
     textValue: json['text'] as String,
-    tsSeconds: (json['ts'] as num)?.toDouble(),
+    tsSeconds: (json['ts'] as num)?.toDouble()?.round(),
+    tsMicros: (json['ts_m'] as num)?.toInt(),
     quote: json['quote'] == null
         ? null
         : Quote.fromJson(json['quote'] as Map<String, dynamic>),
@@ -50,6 +51,7 @@ Map<String, dynamic> _$MessageToJson(Message instance) => <String, dynamic>{
       'sessionId': instance.sessionId,
       'text': instance.textValue,
       'ts': instance.tsSeconds,
+      'ts_m': instance.tsMicros,
       'modifiedTs': instance.modified,
       'quote': instance.quote,
     };

--- a/lib/src/util/num_extension.dart
+++ b/lib/src/util/num_extension.dart
@@ -1,0 +1,7 @@
+extension NumExtension on num {
+  /// from seconds to microseconds
+  num fromSecToMicro() => Duration(seconds: this.round()).inMicroseconds;
+
+  /// from microseconds to seconds
+  num fromMicroToSec() => Duration(microseconds: this.round()).inSeconds;
+}

--- a/lib/src/webim_session.dart
+++ b/lib/src/webim_session.dart
@@ -101,7 +101,7 @@ class WebimSession {
       textValue: text,
       kind: WMMessageKind.VISITOR,
       clientSideId: IdGenerator.messageClientSideId,
-      tsSeconds: (DateTime.now().millisecondsSinceEpoch / 1000).toDouble(),
+      tsSeconds: (DateTime.now().millisecondsSinceEpoch / 1000).round(),
     );
     final messageEvent = DeltaItem<Message>(
       objectType: DeltaItemType.CHAT_MESSAGE,
@@ -119,7 +119,7 @@ class WebimSession {
       textValue: file.path,
       kind: WMMessageKind.FILE_FROM_VISITOR,
       clientSideId: IdGenerator.messageClientSideId,
-      tsSeconds: (DateTime.now().millisecondsSinceEpoch / 1000).toDouble(),
+      tsSeconds: (DateTime.now().millisecondsSinceEpoch / 1000).round(),
       data: MessageData(
         file: MessageFile(
           state: FileState.UPLOAD,


### PR DESCRIPTION
_Что сделано:_
подебажил параметр `before-ts` в запросе истории и увидел, что абсолютно всегда приходит пустой респонс
попрбовал заменить на `before` - заработало, данные пришли в полной мере (но формат даты сообщения пришел в микросекундах, а не секундах. немного доработал `Message` из-за этого)